### PR TITLE
Allow people to use Github as an issue tracker.

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/DAGOLDEN.pm
+++ b/lib/Dist/Zilla/PluginBundle/DAGOLDEN.pm
@@ -121,7 +121,8 @@ has git_remote => (
 has no_bugtracker => (
   is      => 'ro',
   isa     => 'Bool',
-  default => 0,
+  lazy    => 1,
+  default => sub { $_[0]->payload->{no_bugtracker} || 0 },
 );
 
 


### PR DESCRIPTION
Currently RT is the issue tracker.  This commit changes nothing about the
default behavior.  But it allows users to select optionally use Github as an issue
tracker with the help of Dist::Zilla::Plugin::Filter.

People can do this using the following in their dist.ini:

[@Filter]
-bundle = @DAGOLDEN
-remove = Bugtracker
