### PR TITLE
Fixes for no_critic and no_spellcheck.

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/DAGOLDEN.pm
+++ b/lib/Dist/Zilla/PluginBundle/DAGOLDEN.pm
@@ -172,9 +172,9 @@ sub configure {
     [ 'Test::Compile' => { fake_home => 1 } ],
 
   # generated xt/ tests
-    $self->no_spellcheck 
+    ( $self->no_spellcheck 
         ? () 
-        : [ 'Test::PodSpelling' => { stopwords => $self->stopwords } ],
+        : [ 'Test::PodSpelling' => { stopwords => $self->stopwords } ] ),
     'Test::Perl::Critic',
     'MetaTests',          # core
     'PodSyntaxTests',     # core


### PR DESCRIPTION
no_critic and no_spellcheck options were being ignored.  Now they aren't.
