### PR TITLE
Allow dirty cpanfile or Makefile.PL before release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+# https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html
+김도형 - Keedi Kim <keedi@cpan.org> <keedi.k@gmail.com>
+김도형 - Keedi Kim <keedi@cpan.org> <keedi@cpan.org>

--- a/lib/Dist/Zilla/PluginBundle/DAGOLDEN.pm
+++ b/lib/Dist/Zilla/PluginBundle/DAGOLDEN.pm
@@ -383,7 +383,10 @@ sub configure {
         ),
         (
             $self->no_git ? ()
-            : [ 'Git::Check' => { allow_dirty => undef } ]
+            : [
+                'Git::Check' =>
+                  { allow_dirty => [ $self->auto_version ? 'cpanfile' : 'Makefile.PL' ] }
+            ]
         ),
         'CheckMetaResources',
         'CheckPrereqsIndexed',


### PR DESCRIPTION
This plugin bundle copies `cpanfile` or `Makefile.PL` using `CopyFilesFromBuild`, but doesn't allow any dirty files before release. So, when `Makefile.PL` is changed during release, release process is stopped due to `Git::Check`.  I think `Git::Check` should allow `cpanfile` or `Makefile.PL` like `CopyFilesFromBuild`.

If this PR is not proper approach, then just ignore and close plz. :)
